### PR TITLE
Compatibility w/ new Ouster driver and Ubuntu 20.04

### DIFF
--- a/lidar_undistortion/CMakeLists.txt
+++ b/lidar_undistortion/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(lidar_undistortion)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)

--- a/lidar_undistortion/src/lidar_undistorter.cpp
+++ b/lidar_undistortion/src/lidar_undistorter.cpp
@@ -1,5 +1,5 @@
 #include "lidar_undistortion/lidar_undistorter.h"
-#include <ouster_ros/point_os1.h>
+#include <ouster_ros/point.h>
 #include <pcl/common/transforms.h>
 #include <pcl/point_cloud.h>
 #include <pcl_conversions/pcl_conversions.h>
@@ -28,7 +28,7 @@ LidarUndistorter::LidarUndistorter(ros::NodeHandle nh,
 void LidarUndistorter::pointcloudCallback(
     const sensor_msgs::PointCloud2 &pointcloud_msg) {
   // Convert the pointcloud to PCL
-  pcl::PointCloud<ouster_ros::OS1::PointOS1> pointcloud;
+  pcl::PointCloud<ouster_ros::Point> pointcloud;
   pcl::fromROSMsg(pointcloud_msg, pointcloud);
 
   // Assert that the pointcloud is not empty
@@ -64,7 +64,7 @@ void LidarUndistorter::pointcloudCallback(
     // each point's timestamp
     uint32_t last_transform_update_t = 0;
     Eigen::Affine3f T_S_original__S_corrected = Eigen::Affine3f::Identity();
-    for (ouster_ros::OS1::PointOS1 &point : pointcloud.points) {
+    for (ouster_ros::Point &point : pointcloud.points) {
       // Check if the current point's timestamp differs from the previous one
       // If so, lookup the new corresponding transform
       if (point.t != last_transform_update_t) {


### PR DESCRIPTION
@patripfr created this branch  - I think we could merge this to master.

Changes needed:
 - new point type include due to new ouster driver version
 - c++14 for compatibility with new PCL

WDYT @victorreijgwart @patripfr 